### PR TITLE
Add "Moonlight II" theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If not, new themes can be add added with a pull request. Just add them to the li
 - Monokai Cmder by [vdurante](https://github.com/vdurante/windows-terminal-monokai-cmder)
 - Rosé Pine by [mvllow](https://github.com/mvllow)
 - Tokyo Night by [enkia](https://github.com/enkia)
+- Moonlight II by [atomiks](https://github.com/atomiks)
 
 ## Running
 

--- a/app/src/custom-colour-schemes.json
+++ b/app/src/custom-colour-schemes.json
@@ -210,5 +210,26 @@
     "brightWhite": "#828594",
     "background": "#cbccd1",
     "foreground": "#4c505e"
+  },
+  {
+    "name": "Moonlight II",
+    "black": "#191a2a",
+    "red": "#ff757f",
+    "green": "#c3e88d",
+    "yellow": "#ffc777",
+    "blue": "#82aaff",
+    "purple": "#c099ff",
+    "cyan": "#86e1fc",
+    "white": "#c8d3f5",
+    "brightBlack": "#828bb8",
+    "brightRed": "#ff757f",
+    "brightGreen": "#c3e88d",
+    "brightYellow": "#ffc777",
+    "brightBlue": "#82aaff",
+    "brightPurple": "#c099ff",
+    "brightCyan": "#86e1fc",
+    "brightWhite": "#c8d3f5",
+    "background": "#222436",
+    "foreground": "#c8d3f5"
   }
 ]


### PR DESCRIPTION
Recently found another VS Code theme called [Moonlight](https://marketplace.visualstudio.com/items?itemName=atomiks.moonlight) (it's version 2 now, hence the **II** in the latest iteration) by atomiks. It is somewhat similar to Tokyo Night (the previous theme in my previous pull request), but I'm pretty fond of the higher contrast or more vibrant colors of Moonlight II.

Apologies if it seems like I'm adding themes too often 😅