### PR TITLE
Add Monokai (filter Octagon) theme

### DIFF
--- a/server/themes.json
+++ b/server/themes.json
@@ -2950,6 +2950,27 @@
     "isDark": true
   },
   {
+    "name": "Monokai Octagon",
+    "black": "#000000",
+    "red": "#d81e00",
+    "green": "#5ea702",
+    "yellow": "#cfae00",
+    "blue": "#427ab3",
+    "purple": "#89658e",
+    "cyan": "#00a7aa",
+    "white": "#dbded8",
+    "brightBlack": "#686a66",
+    "brightRed": "#f54235",
+    "brightGreen": "#99e343",
+    "brightYellow": "#fdeb61",
+    "brightBlue": "#84b0d8",
+    "brightPurple": "#bc94b7",
+    "brightCyan": "#37e6e8",
+    "brightWhite": "#f1f1f0",
+    "background": "#282a3a",
+    "foreground": "#eaf2f1"
+  },
+  {
     "name": "Monokai Remastered",
     "black": "#1a1a1a",
     "red": "#f4005f",


### PR DESCRIPTION
This is a theme for Sublime and VSCode by [Monokai Pro](https://monokai.pro/).

I added it for my personal use. It's not exactly the octagon color scheme, but it comes as close as possible.