### PR TITLE
Add selectionBackground property for Sonoran Sunrise

### DIFF
--- a/app/src/custom-colour-schemes.json
+++ b/app/src/custom-colour-schemes.json
@@ -259,6 +259,7 @@
     "foreground": "#61543E",
     "background": "#F9FAE3",
     "cursorColor": "#61543E",
+    "selectionBackground": "#a4f017",
     "black": "#F9FAE3",
     "red": "#EB6f6f",
     "green": "#669C50",


### PR DESCRIPTION
This is just a suggestion. The selection background color looks like a highlight on the terminal with the color scheme.