### PR TITLE
Add QB64 Super Dark Blue

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If not, new themes can be add added with a pull request. Just add them to the li
 - Monokai Pro by [monokai](https://monokai.pro)
 - Moonlight II by [atomiks](https://github.com/atomiks)
 - OneDark by [azrikahar](https://github.com/azrikahar)
+- QB64 Super Dark Blue [jmmv](https://github.com/jmmv)
 - Rosé Pine by [mvllow](https://github.com/mvllow)
 - Sonoran Gothic and Sonoran Sunrise by [d-mckee](https://github.com/d-mckee)
 - Sublette by [sublee](https://github.com/sublee)

--- a/app/src/credits.json
+++ b/app/src/credits.json
@@ -133,5 +133,14 @@
         "link": "https://github.com/ShivangMathur1"
       }
     ]
+  },
+  {
+    "themeNames": ["QB64 Super Dark Blue"],
+    "sources": [
+      {
+        "name": "jmmv",
+        "link": "https://github.com/jmmv"
+      }
+    ]
   }
 ]

--- a/app/src/custom-colour-schemes.json
+++ b/app/src/custom-colour-schemes.json
@@ -523,5 +523,28 @@
     "selectionBackground": "#B5D5FF",
     "white": "#E6E6E6",
     "yellow": "#857E39"
+  },
+  {
+    "background": "#000027",
+    "black": "#000000",
+    "blue": "#054663",
+    "brightBlack": "#626262",
+    "brightBlue": "#457693",
+    "brightCyan": "#00586C",
+    "brightGreen": "#55CE55",
+    "brightPurple": "#934593",
+    "brightRed": "#D8624E",
+    "brightWhite": "#D8D8D8",
+    "brightYellow": "#FFA700",
+    "cursorColor": "#D8D8D8",
+    "cyan": "#00485C",
+    "foreground": "#D8D8D8",
+    "green": "#157E15",
+    "name": "QB64 Super Dark Blue",
+    "purple": "#631563",
+    "red": "#98220E",
+    "selectionBackground": "#00586C",
+    "white": "#989898",
+    "yellow": "#808000"
   }
 ]


### PR DESCRIPTION
This theme is based on the color scheme named Super Dark Blue that ships
with QB64.  I took the colors in that theme (which are used to render
code) and mapped them to the bright colors of the terminal, and then I
reduced their brightness to obtain the darker colors.