### PR TITLE
Add Poimandres theme

### DIFF
--- a/app/src/credits.json
+++ b/app/src/credits.json
@@ -182,5 +182,14 @@
         "link": "https://github.com/tel0065"
       }
     ]
-  }
+  },
+  {
+  "themeNames": ["Poimandres"],
+  "sources": [
+    {
+      "name": "adryanrr",
+      "link": "https://github.com/adryanrr"
+    }
+  ]
+}
 ]

--- a/app/src/custom-colour-schemes.json
+++ b/app/src/custom-colour-schemes.json
@@ -982,4 +982,27 @@
     "white": "#000000",
     "yellow": "#F0AA0B"
 },
+{
+    "name": "Poimandres",
+    "background": "#1B1E28",
+    "black": "#1B1E28",
+    "blue": "#DDFFFF",
+    "brightBlack": "#ACCDFF",
+    "brightBlue": "#D7FFFF",
+    "brightCyan": "#D7FFFF",
+    "brightGreen": "#E4C7FF",
+    "brightPurple": "#C5E9FF",
+    "brightRed": "#679DFF",
+    "brightWhite": "#FFFFFF",
+    "brightYellow": "#FAC2FF",
+    "cursorColor": "#B473FF",
+    "cyan": "#DDFFFF",
+    "foreground": "#ACCDFF",
+    "green": "#E4C7FF",
+    "purple": "#C5E9FF",
+    "red": "#679DFF",
+    "selectionBackground": "#7CB424",
+    "white": "#FFFFFF",
+    "yellow": "#FAC2FF"
+}
 ]

--- a/credits/auto-credits.json
+++ b/credits/auto-credits.json
@@ -1693,5 +1693,17 @@
       }
     ],
     "notes": "The scheme Zenburn was inspired by the [Zenburn](http://sunaku.github.io/zenburn-terminal-color-scheme.html) version created by Suraj N. Kurapati."
+  },
+  {
+    "themeNames": [
+      "Poimandres"
+    ],
+    "sources": [
+      {
+        "name": "adryanrr",
+        "link": "https://github.com/Adryanrr/wt-themes"
+      }
+    ],
+    "notes": "The scheme was inspired by the classic Poimandres version, customized by Adryan Ryan."
   }
 ]

--- a/credits/iterm-credits.md
+++ b/credits/iterm-credits.md
@@ -291,3 +291,5 @@ The iceberg theme was created by [cocopon](https://github.com/cocopon/iceberg.vi
 The "Galizur" theme was crafted by [Raziel Anarki](https://github.com/razielanarki)
 
 The [Raycast](https://raycast.com) Dark/Light themes were created by [thomaspaulmann](https://github.com/thomaspaulmann) and [itsnwa](https://github.com/itsnwa).
+
+The **Poimandres** theme was adapted for Windows Terminal by [adryanrr](https://github.com/adryanrr).

--- a/credits/manual-credits.json
+++ b/credits/manual-credits.json
@@ -1661,5 +1661,15 @@
       }
     ],
     "notes": "The iceberg theme was created by cocopon and ported to iTerm2 by pbnj"
-  }
+  },
+  {
+  "themeNames": ["Poimandres"],
+  "sources": [
+    {
+      "name": "adryanrr",
+      "link": "https://github.com/adryanrr"
+    }
+  ],
+  "notes": "The Poimandres theme was adapted for Windows Terminal by [adryanrr](https://github.com/adryanrr)."
+}
 ]


### PR DESCRIPTION
This PR adds the **Poimandres** color scheme to the Windows Terminal theme collection.

* 🎨 Theme name: `Poimandres`
* 🌙 A calm, deep-space-inspired palette

* Background: `#1B1E28`
* Foreground: `#ACCDFF`
* Accent colors based on soft cyans, purples, and blues for minimal eye strain

This addition helps users achieve a soothing and focused terminal aesthetic, great for long coding sessions.